### PR TITLE
Don't use (old) future reserved words

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ var y = d * 365.25;
 module.exports = function(val, options){
   options = options || {};
   if ('string' == typeof val) return parse(val);
-  return options.long
-    ? long(val)
-    : short(val);
+  return options['long']
+    ? _long(val)
+    : _short(val);
 };
 
 /**
@@ -88,7 +88,7 @@ function parse(str) {
  * @api private
  */
 
-function short(ms) {
+function _short(ms) {
   if (ms >= d) return Math.round(ms / d) + 'd';
   if (ms >= h) return Math.round(ms / h) + 'h';
   if (ms >= m) return Math.round(ms / m) + 'm';
@@ -104,7 +104,7 @@ function short(ms) {
  * @api private
  */
 
-function long(ms) {
+function _long(ms) {
   return plural(ms, d, 'day')
     || plural(ms, h, 'hour')
     || plural(ms, m, 'minute')


### PR DESCRIPTION
`long` and `short` used to be [future reserved words](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords) in ECMAScript 1 till 3. As such, some tools like [YUI Compressor](https://github.com/yui/yuicompressor) will choke on ms.js. This is a workaround for such tools.