### PR TITLE
Fixed package.json repository url field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Tiny ms conversion utility",
   "repository": {
     "type": "git",
-    "url": "git://github.com/guille/ms.js.git"
+    "url": "git://github.com/rauchg/ms.js.git"
   },
   "main": "./index",
   "devDependencies": {


### PR DESCRIPTION
Updated repository.url field in package.json for applications that use the url directly. E.g. david-dm