### PR TITLE
Rename `long` and `short`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = function(val, options){
   options = options || {};
   if ('string' == typeof val) return parse(val);
   return options.long
-    ? long(val)
-    : short(val);
+    ? fmtLong(val)
+    : fmtShort(val);
 };
 
 /**
@@ -90,7 +90,7 @@ function parse(str) {
  * @api private
  */
 
-function short(ms) {
+function fmtShort(ms) {
   if (ms >= d) return Math.round(ms / d) + 'd';
   if (ms >= h) return Math.round(ms / h) + 'h';
   if (ms >= m) return Math.round(ms / m) + 'm';
@@ -106,7 +106,7 @@ function short(ms) {
  * @api private
  */
 
-function long(ms) {
+function fmtLong(ms) {
   return plural(ms, d, 'day')
     || plural(ms, h, 'hour')
     || plural(ms, m, 'minute')

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var y = d * 365.25;
 module.exports = function(val, options){
   options = options || {};
   if ('string' == typeof val) return parse(val);
-  return options.long
+  return options['long']
     ? fmtLong(val)
     : fmtShort(val);
 };


### PR DESCRIPTION
Cause it is reserved words in ES1-3. It is ok for ES2015, but it still breaks down Closure Compiler.